### PR TITLE
Remove UB

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
     u64 outsize=0;
     res = nsListApplicationRecord(appRecords, 1024, 0,  &actualAppRecordCnt);
 
-    appletRequestLaunchApplication(appRecords[rand()% actualAppRecordCnt+1].application_id, NULL);
+    appletRequestLaunchApplication(appRecords[rand() % actualAppRecordCnt].application_id, NULL);
 
 
     // Main loop


### PR DESCRIPTION
example:

`rand()` = 1023
`actualAppRecordCnt` = 1024

`rand % actualAppRecordCnt`: 1023
`1023 + 1` = 1024 << outside of `appRecords` array

this "+1" is completely unnecesary
